### PR TITLE
Updated Helm download to use the new CDN as well as to use 3.4.0 instead of 2.15.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,9 +107,9 @@ RUN curl -L https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL
 # HELM
 # ========================================
 
-ENV HELM_VERSION=2.15.1
+ENV HELM_VERSION=3.4.0
 
-RUN curl -L https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz -o helm.tgz \
+RUN curl -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -o helm.tgz \
     && tar -zxvf helm.tgz \
     && rm helm.tgz \
     && mv linux-amd64/helm /usr/local/bin/ \


### PR DESCRIPTION
<img width="1600" alt="image" src="https://user-images.githubusercontent.com/1633308/98661771-309a4980-2347-11eb-90b8-fc7b2a77f8e7.png">

Took a stab at https://github.com/dfds/cloudplatform/issues/116