### PR TITLE
Add kubectl crossplane plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,13 @@ RUN curl -L https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL
     && chmod +x kubectl \
     && mv kubectl /usr/local/bin/
 
+# ========================================
+# KUBECTL CROSSPLANE PLUGIN
+# ========================================
+
+RUN curl -sL https://raw.githubusercontent.com/crossplane/crossplane/release-1.0/install.sh | sh \
+    && mv kubectl-crossplane /usr/local/bin
+
 
 # ========================================
 # HELM

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To run the Docker image locally or in a build pipeline, Docker is required.
 In order to pull the image, run:
 
 ```
-docker push dfdsdk/prime-pipeline:tagname
+docker pull dfdsdk/prime-pipeline:tagname
 ```
 Replace tagname with the release number of the release you wish to pull.
 Releases can be found on [Docker Hub](https://hub.docker.com/r/dfdsdk/prime-pipeline/tags).


### PR DESCRIPTION
This PR adds the crossplane kubectl plugin to the docker image

It also fixes an error in the README with the pull instructions