### PR TITLE
Hardening Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,33 +43,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: results.sarif
-  # Push image to GitHub Packages.
-  # push:
-  #   # Ensure test job passes before pushing image.
-  #   needs: test
-  #   runs-on: ubuntu-latest
-  #   if: github.event_name == 'push' || github.event_name == 'release'
-  #   permissions:
-  #     contents: read
-  #     packages: write
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Build image
-  #       run: docker build . --file Dockerfile --tag $IMAGE_NAME
-  #     - name: Log into registry
-  #       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-  #     - name: Push image
-  #       run: |
-  #         IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
-  #         # Change all uppercase to lowercase
-  #         IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-  #         # Strip git ref prefix from version
-  #         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-  #         # Strip "v" prefix from tag name
-  #         [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-  #         # Use Docker `latest` tag convention
-  #         [ "$VERSION" == "main" ] && VERSION=latest
-  #         echo IMAGE_ID=$IMAGE_ID
-  #         echo VERSION=$VERSION
-  #         docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-  #         docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
             docker build . --file Dockerfile --tag localbuild/testimage:latest
           fi
       - name: Run the Anchore scan action itself with GitHub Advanced Security code scanning integration enabled
-        uses: anchore/scan-action@main
+        uses: anchore/scan-action@v3
         with:
           image: "localbuild/testimage:latest"
           acs-report-enable: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Docker Build, Scan and Publish
+name: Docker Build and Scan
 
 on:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,7 @@ jobs:
           else
             docker build . --file Dockerfile --tag localbuild/testimage:latest
           fi
+
       - name: Run the Anchore scan action itself with GitHub Advanced Security code scanning integration enabled
         uses: anchore/scan-action@v3
         with:
@@ -39,7 +40,13 @@ jobs:
           acs-report-enable: true
           fail-build: false
           severity-cutoff: high
+
       - name: Upload Anchore Scan Report
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: results.sarif
+
+      - name: Create software bill of materials when releasing
+        uses: anchore/sbom-action@v0
+        with:
+          image: localbuild/testimage:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,11 @@ jobs:
         with:
           sarif_file: results.sarif
 
+      - name: Inspect action SARIF report
+        run: cat ${{ steps.scan.outputs.sarif }}
+
       - name: Create software bill of materials when releasing
         uses: anchore/sbom-action@v0
         with:
           image: localbuild/testimage:latest
+          artifact-name: sbom.spdx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Run the Anchore scan action itself with GitHub Advanced Security code scanning integration enabled
         uses: anchore/scan-action@v3
+        id: scan
         with:
           image: "localbuild/testimage:latest"
           acs-report-enable: true
@@ -44,7 +45,7 @@ jobs:
       - name: Upload Anchore Scan Report
         uses: github/codeql-action/upload-sarif@v1
         with:
-          sarif_file: results.sarif
+          sarif_file: ${{ steps.scan.outputs.sarif }}
 
       - name: Inspect action SARIF report
         run: cat ${{ steps.scan.outputs.sarif }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run tests
+      - name: Build Docker image locally
         run: |
           if [ -f docker-compose.test.yml ]; then
             docker-compose --file docker-compose.test.yml build
@@ -47,11 +47,9 @@ jobs:
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 
-      - name: Inspect action SARIF report
-        run: cat ${{ steps.scan.outputs.sarif }}
-
       - name: Create software bill of materials when releasing
         uses: anchore/sbom-action@v0
         with:
           image: localbuild/testimage:latest
           artifact-name: sbom.spdx
+        if: github.event_name == 'release'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # CREATE UPDATED BASE IMAGE
 # ========================================
 
-FROM debian:bullseye-slim AS base
+FROM debian:testing-slim AS base
 
 RUN apt-get update \
     && apt-get dist-upgrade -y \
@@ -30,20 +30,11 @@ RUN ssh -T -o "StrictHostKeyChecking no" -o "PubkeyAuthentication no" git@github
 
 ADD src /
 
-# # ========================================
-# # PYTHON
-# # ========================================
-
-# RUN apt-get update \
-#     && apt-get install -y python python-pip python3 python3-pip \
-#     && apt-get clean \
-#     && rm -rf /var/lib/apt/lists/*
-
 # ========================================
 # AWS CLI
 # ========================================
 
-ENV AWS_CLI_VERSION=2.2.43
+ENV AWS_CLI_VERSION=2.4.7
 
 RUN curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip -o awscliv2.zip \
     && curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip.sig  -o awscliv2.sig \
@@ -80,7 +71,7 @@ RUN curl -Os https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terra
 # TERRAGRUNT
 # ========================================
 
-ENV TERRAGRUNT_VERSION=0.35.13
+ENV TERRAGRUNT_VERSION=0.35.16
 
 RUN curl -L https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 -o terragrunt \
     && chmod +x terragrunt \
@@ -92,7 +83,7 @@ RUN curl -L https://github.com/gruntwork-io/terragrunt/releases/download/v${TERR
 # ========================================
 
 
-ENV KUBECTL_VERSION=1.21.7
+ENV KUBECTL_VERSION=1.21.8
 
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o kubectl \
     && curl -Os https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256 \
@@ -137,18 +128,6 @@ RUN curl -L https://amazon-eks.s3-us-west-2.amazonaws.com/${AWSIAMAUTH_VERSION}/
 
 
 # ========================================
-# SAML2AWS
-# ========================================
-
-# ENV SAML2AWS_VERSION=2.13.0
-
-# RUN curl -L "https://github.com/Versent/saml2aws/releases/download/v${SAML2AWS_VERSION}/saml2aws_${SAML2AWS_VERSION}_linux_amd64.tar.gz" -o saml2aws.tar.gz \
-#     && tar -zxvf saml2aws.tar.gz \
-#     && rm saml2aws.tar.gz \
-#     && mv saml2aws /usr/local/bin/
-
-
-# ========================================
 # KAFKA MESSAGE PRODUCER
 # ========================================
 
@@ -162,7 +141,7 @@ RUN apt-get update \
 # ========================================
 
 
-ENV FLUXCD_VERSION=0.24.0
+ENV FLUXCD_VERSION=0.24.1
 
 RUN curl -LO https://github.com/fluxcd/flux2/releases/download/v${FLUXCD_VERSION}/flux_${FLUXCD_VERSION}_linux_amd64.tar.gz \
     && curl -LO https://github.com/fluxcd/flux2/releases/download/v${FLUXCD_VERSION}/flux_${FLUXCD_VERSION}_checksums.txt \
@@ -178,15 +157,3 @@ RUN curl -LO https://github.com/fluxcd/flux2/releases/download/v${FLUXCD_VERSION
 # ========================================
 
 CMD [ "bash" ]
-
-# ========================================
-# ISSUES
-# ========================================
-
-# debconf: unable to initialize frontend: Dialog
-# debconf: (TERM is not set, so the dialog frontend is not usable.)
-# debconf: falling back to frontend: Readline
-# debconf: unable to initialize frontend: Readline
-# debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.24.1 /usr/local/share/perl/5.24.1 /usr/lib/x86_64-linux-gnu/perl5/5.24 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.24 /usr/share/perl/5.24 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7, <> line 3.)
-# debconf: falling back to frontend: Teletype
-# dpkg-preconfigure: unable to re-open stdin:


### PR DESCRIPTION
**SECURITY:**
- Using debian:testing-slim instead of debian:bullseye-slim, because the testing release is closer to upstream (while still quite stable), and has hence fewer security issues.
- debian:testing-slim currently has zero vulnerabilities.
- The number of vulnerabilities will drop from 400+ to 58
- The vulnerabilities currently in our image is caused by the 3rd party tools we install
- The 3rd party tools are currentlt patched to latest and greatest

**FEATURES**
- The release process will now also create a software bill of materials (SBOM) artifact. This gives us better visibilities on what we are depending on.