### PR TITLE
use arm64 compatible base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ ENV POWERSHELL_VERSION=7.3.2
 ENV AWSPOWERSHELL_VERSION=4.1.14
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
-    if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
+    if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=x64; fi; \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
     curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz
 RUN mkdir -p /opt/microsoft/powershell/7 && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # CREATE UPDATED BASE IMAGE
 # ========================================
 
-FROM mcr.microsoft.com/powershell:debian-bullseye-slim AS base
+FROM debian:bullseye-slim AS base
 
 RUN apt-get update \
     && apt-get dist-upgrade -y \
@@ -50,9 +50,22 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 
 ENV AWS_PAGER=""
 
+# ========================================
+# POWERSHELL
+# ========================================
+
+ENV POWERSHELL_VERSION=7.3.2
 ENV AWSPOWERSHELL_VERSION=4.1.14
 
+RUN export BUILD_ARCHITECTURE=$(uname -m); \
+    if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
+    if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
+    curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz
+RUN mkdir -p /opt/microsoft/powershell/7 && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
 RUN pwsh -Command Install-Module AWSPowerShell.NetCore -Scope AllUsers -AcceptLicense -Force -RequiredVersion ${AWSPOWERSHELL_VERSION}
+
 
 # ========================================
 # TERRAFORM


### PR DESCRIPTION
I noticed that the base image is not arm64 compatible so I have made changes to make it so. This will let us run on arm64 (i.e Mac M1/M2) natively without having to emulate, for example