### PR TITLE
Updated kubectl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # ========================================
 
 
-ENV KUBECTL_VERSION=1.23.15
+ENV KUBECTL_VERSION=1.24.11
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \


### PR DESCRIPTION
Build the image locally and seemed to work just fine. Produced:

```bash
kubectl version -o json
{
  "clientVersion": {
    "major": "1",
    "minor": "24",
    "gitVersion": "v1.24.11",
    "gitCommit": "0f75679e3346160939924550fd3591462a4afec6",
    "gitTreeState": "clean",
    "buildDate": "2023-02-22T13:39:33Z",
    "goVersion": "go1.19.6",
    "compiler": "gc",
    "platform": "linux/amd64"
  },
  "kustomizeVersion": "v4.5.4"
}
```