### PR TITLE
Upgrade all tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ADD src /
 # AWS CLI
 # ========================================
 
-ENV AWS_CLI_VERSION=2.13.29
+ENV AWS_CLI_VERSION=2.15.38
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -55,7 +55,7 @@ ENV AWS_PAGER=""
 # TERRAFORM
 # ========================================
 
-ENV TERRAFORM_VERSION=1.4.6
+ENV TERRAFORM_VERSION=1.5.7
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -77,7 +77,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # TERRAGRUNT
 # ========================================
 
-ENV TERRAGRUNT_VERSION=0.45.16
+ENV TERRAGRUNT_VERSION=0.57.1
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -92,7 +92,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # ========================================
 
 
-ENV KUBECTL_VERSION=1.28.3
+ENV KUBECTL_VERSION=1.29.3
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -110,7 +110,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # ========================================
 
 
-ENV KUSTOMIZE_VERSION=5.2.1
+ENV KUSTOMIZE_VERSION=5.4.1
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -130,7 +130,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # HELM
 # ========================================
 
-ENV HELM_VERSION=3.13.1
+ENV HELM_VERSION=3.14.4
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -157,7 +157,7 @@ RUN apt-get update \
 # Flux CD
 # ========================================
 
-ENV FLUXCD_VERSION=2.1.2
+ENV FLUXCD_VERSION=2.2.3
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -175,7 +175,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # Go
 # ========================================
 
-ENV GO_VERSION=1.19.5
+ENV GO_VERSION=1.22.2
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -190,7 +190,7 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 # Eksctl
 # ========================================
 
-ENV EKSCTL_VERSION=0.163.0
+ENV EKSCTL_VERSION=0.175.0
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -208,7 +208,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # k9s
 # ========================================
 
-ENV K9S_VERSION=0.27.4
+ENV K9S_VERSION=0.32.4
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -225,7 +225,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # Azure CLI
 # ========================================
 
-ENV AZ_VERSION=2.58.0
+ENV AZ_VERSION=2.59.0
 
 RUN pip3 install azure-cli==${AZ_VERSION}
 


### PR DESCRIPTION
Related to https://github.com/dfds/cloudplatform/issues/2774 which is about Atlantis not able to run properly after upgradting the Terraform Helm provider. 

- Downgrading Terraform Helm provider.
- Want to test if upgrading tools works too; in particular Terraform, Terragrunt and Atlantis.

A local build of this Docker image is tested in my sandbox