### PR TITLE
Upgrade all tools. Add mimirtool Standardize curl to use -sSLo or -sSLO when downloading Add missing checksum checks for many of our downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # CREATE UPDATED BASE IMAGE
 # ========================================
 
-FROM debian:bullseye-slim AS base
+FROM debian:bookworm-slim AS base
 
 RUN apt-get update \
     && apt-get dist-upgrade -y \
@@ -33,8 +33,7 @@ FROM prereqs
 RUN apt-get update \
     && apt-get install -y kafkacat \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && ln -s /usr/bin/kafkacat /usr/bin/kcat
+    && rm -rf /var/lib/apt/lists/*
 
 # ========================================
 # COPY SCRIPTS AND FILES
@@ -275,9 +274,9 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # Azure CLI https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli
 # ========================================
 
-ENV AZ_VERSION=2.65.0
+# ENV AZ_VERSION=2.65.0 # Using latest stable version recommended by Microsoft
 
-RUN pip3 install azure-cli==${AZ_VERSION}
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
 # ========================================
 # END

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,10 +78,10 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
     && curl -sSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS.sig \
     && gpg --import /tmp/files/hashicorp.asc \
     && gpg --verify terraform_${TERRAFORM_VERSION}_SHA256SUMS.sig terraform_${TERRAFORM_VERSION}_SHA256SUMS \
-    && grep terraform_${TERRAFORM_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip terraform_${TERRAFORM_VERSION}_SHA256SUMS > terraform_${TERRAFORM_VERSION}_SHA256SUM \
-    && shasum -a 256 -c terraform_${TERRAFORM_VERSION}_SHA256SUM \
+    && grep terraform_${TERRAFORM_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip terraform_${TERRAFORM_VERSION}_SHA256SUMS > SHA256SUM \
+    && sha256sum --check SHA256SUM \
     && unzip terraform_${TERRAFORM_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip \
-    && rm -f terraform_${TERRAFORM_VERSION}_* /tmp/files/hashicorp.asc \
+    && rm -f terraform_${TERRAFORM_VERSION}_* /tmp/files/hashicorp.asc SHA256SUM \
     && mv terraform /usr/local/bin/terraform \
     && /usr/local/bin/terraform -install-autocomplete
 
@@ -96,10 +96,10 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
     curl -sSLO https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip \
     && curl -sSLO https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_SHA256SUMS \
-    && grep tofu_${OPENTOFU_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip tofu_${OPENTOFU_VERSION}_SHA256SUMS > tofu_${OPENTOFU_VERSION}_SHA256SUM \
-    && shasum -a 256 -c tofu_${OPENTOFU_VERSION}_SHA256SUM \
+    && grep tofu_${OPENTOFU_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip tofu_${OPENTOFU_VERSION}_SHA256SUMS > SHA256SUM \
+    && sha256sum --check SHA256SUM \
     && /tmp/scripts/install-tofu.sh \
-    && rm -f tofu_${OPENTOFU_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip tofu_${OPENTOFU_VERSION}_SHA256SUM* /tmp/scripts/install-tofu.sh
+    && rm -f tofu_${OPENTOFU_VERSION}_* /tmp/scripts/install-tofu.sh SHA256SUM
 
 
 # ========================================
@@ -113,11 +113,11 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
     curl -sSLO https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_${BUILD_ARCHITECTURE_ARCH} \
     && curl -sSLO https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/SHA256SUMS \
-    && grep terragrunt_linux_${BUILD_ARCHITECTURE_ARCH} SHA256SUMS > terragrunt_SHA256SUM \
-    && shasum -a 256 -c terragrunt_SHA256SUM \
+    && grep terragrunt_linux_${BUILD_ARCHITECTURE_ARCH} SHA256SUMS > SHA256SUM \
+    && sha256sum --check SHA256SUM \
     && mv terragrunt_linux_${BUILD_ARCHITECTURE_ARCH} /usr/local/bin/terragrunt \
     && chmod +x /usr/local/bin/terragrunt \
-    && rm -f SHA256SUMS terragrunt_SHA256SUM
+    && rm -f SHA256SUM*
 
 
 # ========================================
@@ -150,13 +150,12 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
     curl -sSLO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && curl -sSLO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/checksums.txt \
-    && grep kustomize_v${KUSTOMIZE_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz checksums.txt > kustomize_linux_${BUILD_ARCHITECTURE_ARCH}_checksum.txt \
-    && shasum -a 256 -c kustomize_linux_${BUILD_ARCHITECTURE_ARCH}_checksum.txt \
+    && grep kustomize_v${KUSTOMIZE_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz checksums.txt > SHA256SUM \
+    && sha256sum --check SHA256SUM \
     && tar -zxvf kustomize_v${KUSTOMIZE_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
-    && rm kustomize_v${KUSTOMIZE_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && chmod +x kustomize \
     && mv kustomize /usr/local/bin/ \
-    && rm -f checksums.txt kustomize_linux_${BUILD_ARCHITECTURE_ARCH}_checksum.txt
+    && rm -f rm kustomize_v${KUSTOMIZE_VERSION}_* checksums.txt SHA256SUM
 
 
 # ========================================
@@ -170,10 +169,10 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
     curl -sSLO https://get.helm.sh/helm-v${HELM_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && curl -sSLO https://get.helm.sh/helm-v${HELM_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz.sha256sum \
-    && shasum -a 256 -c helm-v${HELM_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz.sha256sum \
+    && sha256sum --check helm-v${HELM_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz.sha256sum \
     && tar zxvf helm-v${HELM_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && mv linux-${BUILD_ARCHITECTURE_ARCH}/helm /usr/local/bin/ \
-    && rm -R linux-${BUILD_ARCHITECTURE_ARCH} helm-v${HELM_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz.* \
+    && rm -rf linux-${BUILD_ARCHITECTURE_ARCH} helm-v${HELM_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}* CHANGELOG.md \
     && echo "source <(helm completion bash)" >> ~/.bashrc
 
 # ========================================
@@ -187,12 +186,12 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
     curl -sSLO https://github.com/fluxcd/flux2/releases/download/v${FLUXCD_VERSION}/flux_${FLUXCD_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && curl -sSLO https://github.com/fluxcd/flux2/releases/download/v${FLUXCD_VERSION}/flux_${FLUXCD_VERSION}_checksums.txt \
-    && grep flux_${FLUXCD_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz flux_${FLUXCD_VERSION}_checksums.txt > flux_checksum.txt \
-    && shasum -a 256 -c flux_checksum.txt \
+    && grep flux_${FLUXCD_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz flux_${FLUXCD_VERSION}_checksums.txt > SHA256SUM \
+    && sha256sum --check SHA256SUM \
     && tar zxvf flux_${FLUXCD_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && chmod +x flux \
     && mv flux /usr/local/bin/ \
-    && rm -f flux_checksum.txt flux_${FLUXCD_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz flux_${FLUXCD_VERSION}_checksums.txt
+    && rm -f flux_${FLUXCD_VERSION}_* SHA256SUM
 
 # ========================================
 # Go https://go.dev/dl/
@@ -220,12 +219,12 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
     curl -sSLO https://github.com/eksctl-io/eksctl/releases/download/v${EKSCTL_VERSION}/eksctl_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && curl -sSLO https://github.com/eksctl-io/eksctl/releases/download/v${EKSCTL_VERSION}/eksctl_checksums.txt \
-    && grep eksctl_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz eksctl_checksums.txt > eksctl_checksum.txt \
-    && shasum -a 256 -c eksctl_checksum.txt \
+    && grep eksctl_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz eksctl_checksums.txt > SHA256SUM \
+    && sha256sum --check SHA256SUM \
     && tar zxvf eksctl_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && chmod +x eksctl \
     && mv eksctl /usr/local/bin/ \
-    && rm -f eksctl_checksum.txt eksctl_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz eksctl_checksums.txt
+    && rm -f eksctl_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz eksctl_checksums.txt SHA256SUM
 
 # ========================================
 # k9s https://github.com/derailed/k9s/releases
@@ -238,12 +237,12 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
     curl -sSLO https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && curl -sSLO https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/checksums.sha256 \
-    && grep k9s_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz checksums.sha256 | grep -v sbom > k9s_checksum.txt \
-    && shasum -a 256 -c k9s_checksum.txt \
+    && grep k9s_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz checksums.sha256 | grep -v sbom > SHA256SUM \
+    && sha256sum --check SHA256SUM \
     && tar zxvf k9s_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && chmod +x k9s \
     && mv k9s /usr/local/bin/ \
-    && rm -rf LICENSE README.md k9s_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz checksums.sha256
+    && rm -rf LICENSE README.md k9s_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz checksums.sha256 SHA256SUM
 
 # ========================================
 # 1Password CLI https://app-updates.agilebits.com/product_history/CLI2

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
 # GENERAL PREREQUISITES
 # ========================================
 
-FROM base
+FROM base AS prereqs
 
 RUN apt-get update \
     && apt-get install -y curl unzip git bash-completion jq ssh sudo gnupg groff gcc vim python3 python3-pip \
@@ -23,6 +23,18 @@ RUN apt-get update \
 
 # Adding  GitHub public SSH key to known hosts
 RUN ssh -T -o "StrictHostKeyChecking no" -o "PubkeyAuthentication no" git@github.com || true
+
+# ========================================
+# KAFKA MESSAGE PRODUCER
+# ========================================
+
+FROM prereqs
+
+RUN apt-get update \
+    && apt-get install -y kafkacat \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/kafkacat /usr/bin/kcat
 
 # ========================================
 # COPY SCRIPTS AND FILES
@@ -36,13 +48,13 @@ COPY src/temporary /tmp
 # AWS CLI https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst
 # ========================================
 
-ENV AWS_CLI_VERSION=2.17.23
+ENV AWS_CLI_VERSION=2.18.3
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
-    curl -s https://awscli.amazonaws.com/awscli-exe-linux-${BUILD_ARCHITECTURE}-${AWS_CLI_VERSION}.zip -o awscliv2.zip \
-    && curl https://awscli.amazonaws.com/awscli-exe-linux-${BUILD_ARCHITECTURE}-${AWS_CLI_VERSION}.zip.sig  -o awscliv2.sig \
+    curl -sSLo awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-${BUILD_ARCHITECTURE}-${AWS_CLI_VERSION}.zip \
+    && curl -sSLo awscliv2.sig https://awscli.amazonaws.com/awscli-exe-linux-${BUILD_ARCHITECTURE}-${AWS_CLI_VERSION}.zip.sig \
     && gpg --import /tmp/files/aws-cli.asc \
     && gpg --verify awscliv2.sig awscliv2.zip \
     && unzip awscliv2.zip \
@@ -61,9 +73,9 @@ ENV TERRAFORM_VERSION=1.5.7
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
-    curl -Os https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip \
-    && curl -Os https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS \
-    && curl -Os https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS.sig \
+    curl -sSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip \
+    && curl -sSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS \
+    && curl -sSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS.sig \
     && gpg --import /tmp/files/hashicorp.asc \
     && gpg --verify terraform_${TERRAFORM_VERSION}_SHA256SUMS.sig terraform_${TERRAFORM_VERSION}_SHA256SUMS \
     && grep terraform_${TERRAFORM_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip terraform_${TERRAFORM_VERSION}_SHA256SUMS > terraform_${TERRAFORM_VERSION}_SHA256SUM \
@@ -77,29 +89,35 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # OpenTofu https://github.com/opentofu/opentofu/releases
 # ========================================
 
-ENV OPENTOFU_VERSION=1.8.0
+ENV OPENTOFU_VERSION=1.8.3
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
-    curl -LOs https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip \
-    && curl -LOs https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_SHA256SUMS \
+    curl -sSLO https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip \
+    && curl -sSLO https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_SHA256SUMS \
+    && grep tofu_${OPENTOFU_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip tofu_${OPENTOFU_VERSION}_SHA256SUMS > tofu_${OPENTOFU_VERSION}_SHA256SUM \
+    && shasum -a 256 -c tofu_${OPENTOFU_VERSION}_SHA256SUM \
     && /tmp/scripts/install-tofu.sh \
-    && rm -f tofu_${OPENTOFU_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip tofu_${OPENTOFU_VERSION}_SHA256SUMS /tmp/scripts/install-tofu.sh
+    && rm -f tofu_${OPENTOFU_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.zip tofu_${OPENTOFU_VERSION}_SHA256SUM* /tmp/scripts/install-tofu.sh
 
 
 # ========================================
 # TERRAGRUNT https://github.com/gruntwork-io/terragrunt/releases
 # ========================================
 
-ENV TERRAGRUNT_VERSION=0.66.1
+ENV TERRAGRUNT_VERSION=0.68.0
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
-    curl -Ls https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_${BUILD_ARCHITECTURE_ARCH} -o terragrunt \
-    && chmod +x terragrunt \
-    && mv terragrunt /usr/local/bin/
+    curl -sSLO https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_${BUILD_ARCHITECTURE_ARCH} \
+    && curl -sSLO https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/SHA256SUMS \
+    && grep terragrunt_linux_${BUILD_ARCHITECTURE_ARCH} SHA256SUMS > terragrunt_SHA256SUM \
+    && shasum -a 256 -c terragrunt_SHA256SUM \
+    && mv terragrunt_linux_${BUILD_ARCHITECTURE_ARCH} /usr/local/bin/terragrunt \
+    && chmod +x /usr/local/bin/terragrunt \
+    && rm -f SHA256SUMS terragrunt_SHA256SUM
 
 
 # ========================================
@@ -107,13 +125,13 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # ========================================
 
 
-ENV KUBECTL_VERSION=1.30.3
+ENV KUBECTL_VERSION=1.31.0
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
-    curl -Ls https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/${BUILD_ARCHITECTURE_ARCH}/kubectl -o kubectl \
-    && curl -Os https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/${BUILD_ARCHITECTURE_ARCH}/kubectl.sha256 \
+    curl -sSLO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/${BUILD_ARCHITECTURE_ARCH}/kubectl \
+    && curl -sSLO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/${BUILD_ARCHITECTURE_ARCH}/kubectl.sha256 \
     && bash -c 'echo "$(<kubectl.sha256) kubectl" | sha256sum --check' \
     && chmod +x kubectl \
     && mv kubectl /usr/local/bin/ \
@@ -125,60 +143,50 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # ========================================
 
 
-ENV KUSTOMIZE_VERSION=5.4.3
+ENV KUSTOMIZE_VERSION=5.5.0
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
-    curl -LOs https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
-    && curl -Ls https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/checksums.txt -o kustomize_checksums.txt \
-    && grep kustomize_v${KUSTOMIZE_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz kustomize_checksums.txt > kustomize_linux_${BUILD_ARCHITECTURE_ARCH}_checksum.txt \
+    curl -sSLO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
+    && curl -sSLO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/checksums.txt \
+    && grep kustomize_v${KUSTOMIZE_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz checksums.txt > kustomize_linux_${BUILD_ARCHITECTURE_ARCH}_checksum.txt \
     && shasum -a 256 -c kustomize_linux_${BUILD_ARCHITECTURE_ARCH}_checksum.txt \
     && tar -zxvf kustomize_v${KUSTOMIZE_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && rm kustomize_v${KUSTOMIZE_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && chmod +x kustomize \
     && mv kustomize /usr/local/bin/ \
-    && rm -f kustomize_checksums.txt kustomize_linux_${BUILD_ARCHITECTURE_ARCH}_checksum.txt
+    && rm -f checksums.txt kustomize_linux_${BUILD_ARCHITECTURE_ARCH}_checksum.txt
 
 
 # ========================================
 # HELM https://github.com/helm/helm/releases
 # ========================================
 
-ENV HELM_VERSION=3.15.3
+ENV HELM_VERSION=3.16.2
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
-    curl -Ls https://get.helm.sh/helm-v${HELM_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz -o helm.tgz \
-    && tar -zxvf helm.tgz \
-    && rm helm.tgz \
+    curl -sSLO https://get.helm.sh/helm-v${HELM_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz \
+    && curl -sSLO https://get.helm.sh/helm-v${HELM_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz.sha256sum \
+    && shasum -a 256 -c helm-v${HELM_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz.sha256sum \
+    && tar zxvf helm-v${HELM_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && mv linux-${BUILD_ARCHITECTURE_ARCH}/helm /usr/local/bin/ \
-    && rm -R linux-${BUILD_ARCHITECTURE_ARCH} \
+    && rm -R linux-${BUILD_ARCHITECTURE_ARCH} helm-v${HELM_VERSION}-linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz.* \
     && echo "source <(helm completion bash)" >> ~/.bashrc
-
-
-# ========================================
-# KAFKA MESSAGE PRODUCER
-# ========================================
-
-RUN apt-get update \
-    && apt-get install -y kafkacat \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && ln -s /usr/bin/kafkacat /usr/bin/kcat
 
 # ========================================
 # Flux CD https://github.com/fluxcd/flux2/releases
 # ========================================
 
-ENV FLUXCD_VERSION=2.3.0
+ENV FLUXCD_VERSION=2.4.0
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
-    curl -LOs https://github.com/fluxcd/flux2/releases/download/v${FLUXCD_VERSION}/flux_${FLUXCD_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
-    && curl -LO https://github.com/fluxcd/flux2/releases/download/v${FLUXCD_VERSION}/flux_${FLUXCD_VERSION}_checksums.txt \
+    curl -sSLO https://github.com/fluxcd/flux2/releases/download/v${FLUXCD_VERSION}/flux_${FLUXCD_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
+    && curl -sSLO https://github.com/fluxcd/flux2/releases/download/v${FLUXCD_VERSION}/flux_${FLUXCD_VERSION}_checksums.txt \
     && grep flux_${FLUXCD_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz flux_${FLUXCD_VERSION}_checksums.txt > flux_checksum.txt \
     && shasum -a 256 -c flux_checksum.txt \
     && tar zxvf flux_${FLUXCD_VERSION}_linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
@@ -190,12 +198,12 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # Go https://go.dev/dl/
 # ========================================
 
-ENV GO_VERSION=1.22.5
+ENV GO_VERSION=1.23.2
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
-    curl -LOs https://go.dev/dl/go${GO_VERSION}.linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz \
+    curl -sSLO https://go.dev/dl/go${GO_VERSION}.linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && tar -C /usr/local -xzf go${GO_VERSION}.linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && rm -f go${GO_VERSION}.linux-${BUILD_ARCHITECTURE_ARCH}.tar.gz
 
@@ -205,13 +213,13 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 # Eksctl https://github.com/eksctl-io/eksctl/releases
 # ========================================
 
-ENV EKSCTL_VERSION=0.188.0
+ENV EKSCTL_VERSION=0.191.0
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
-    curl -LOs https://github.com/eksctl-io/eksctl/releases/download/v${EKSCTL_VERSION}/eksctl_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
-    && curl -LO https://github.com/eksctl-io/eksctl/releases/download/v${EKSCTL_VERSION}/eksctl_checksums.txt \
+    curl -sSLO https://github.com/eksctl-io/eksctl/releases/download/v${EKSCTL_VERSION}/eksctl_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
+    && curl -sSLO https://github.com/eksctl-io/eksctl/releases/download/v${EKSCTL_VERSION}/eksctl_checksums.txt \
     && grep eksctl_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz eksctl_checksums.txt > eksctl_checksum.txt \
     && shasum -a 256 -c eksctl_checksum.txt \
     && tar zxvf eksctl_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
@@ -228,19 +236,14 @@ ENV K9S_VERSION=0.32.5
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
-    curl -Ls https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz -o k9s.tar.gz \
-    && tar zxvf k9s.tar.gz \
+    curl -sSLO https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
+    && curl -sSLO https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/checksums.sha256 \
+    && grep k9s_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz checksums.sha256 | grep -v sbom > k9s_checksum.txt \
+    && shasum -a 256 -c k9s_checksum.txt \
+    && tar zxvf k9s_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz \
     && chmod +x k9s \
-    && rm -rf k9s.tar.gz LICENSE README.md \
-    && mv k9s /usr/local/bin/
-
-# ========================================
-# Azure CLI https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli
-# ========================================
-
-ENV AZ_VERSION=2.63.0
-
-RUN pip3 install azure-cli==${AZ_VERSION}
+    && mv k9s /usr/local/bin/ \
+    && rm -rf LICENSE README.md k9s_Linux_${BUILD_ARCHITECTURE_ARCH}.tar.gz checksums.sha256
 
 # ========================================
 # 1Password CLI https://app-updates.agilebits.com/product_history/CLI2
@@ -250,9 +253,32 @@ ENV OP_CLI_VERSION=v2.30.0
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
     if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
-    curl -sSfo op.zip https://cache.agilebits.com/dist/1P/op2/pkg/${OP_CLI_VERSION}/op_linux_${BUILD_ARCHITECTURE_ARCH}_${OP_CLI_VERSION}.zip \
-    && unzip -od /usr/local/bin/ op.zip \
-    && rm op.zip
+    curl -sSLO https://cache.agilebits.com/dist/1P/op2/pkg/${OP_CLI_VERSION}/op_linux_${BUILD_ARCHITECTURE_ARCH}_${OP_CLI_VERSION}.zip \
+    && unzip -od /usr/local/bin/ op_linux_${BUILD_ARCHITECTURE_ARCH}_${OP_CLI_VERSION}.zip \
+    && rm op_linux_${BUILD_ARCHITECTURE_ARCH}_${OP_CLI_VERSION}.zip
+
+# ========================================
+# Mimirtool https://github.com/grafana/mimir/releases/
+# ========================================
+ENV MIMIRTOOL_VERSION=2.13.0
+
+RUN export BUILD_ARCHITECTURE=$(uname -m); \
+    if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
+    if [ "$BUILD_ARCHITECTURE" = "aarch64" ]; then export BUILD_ARCHITECTURE_ARCH=arm64; fi; \
+    curl -sSLo mimirtool https://github.com/grafana/mimir/releases/download/mimir-${MIMIRTOOL_VERSION}/mimirtool-linux-${BUILD_ARCHITECTURE_ARCH} \
+    && curl -sSLo mimirtool.sha256 https://github.com/grafana/mimir/releases/download/mimir-${MIMIRTOOL_VERSION}/mimirtool-linux-${BUILD_ARCHITECTURE_ARCH}-sha-256 \
+    && bash -c 'echo "$(<mimirtool.sha256) mimirtool" | sha256sum --check' \
+    && chmod +x mimirtool \
+    && mv mimirtool /usr/local/bin/ \
+    && rm -f mimirtool.sha256
+
+# ========================================
+# Azure CLI https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli
+# ========================================
+
+ENV AZ_VERSION=2.65.0
+
+RUN pip3 install azure-cli==${AZ_VERSION}
 
 # ========================================
 # END


### PR DESCRIPTION
Upgrade all tools. 
Add mimirtool 
Standardize curl to use -sSLo or -sSLO when downloading 
Add missing checksum checks for many of our downloads
Make sure all checksum commands use `sha256sum --check` instead of `shasum -a 256 -c`