### PR TITLE
Update tool versions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY src/temporary /tmp
 # AWS CLI https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst
 # ========================================
 
-ENV AWS_CLI_VERSION=2.27.12
+ENV AWS_CLI_VERSION=2.28.8
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -87,7 +87,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # OpenTofu https://github.com/opentofu/opentofu/releases
 # ========================================
 
-ENV OPENTOFU_VERSION=1.9.1
+ENV OPENTOFU_VERSION=1.10.5
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -103,7 +103,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # TERRAGRUNT https://github.com/gruntwork-io/terragrunt/releases
 # ========================================
 
-ENV TERRAGRUNT_VERSION=0.78.2
+ENV TERRAGRUNT_VERSION=0.84.1
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -139,7 +139,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # ========================================
 
 
-ENV KUSTOMIZE_VERSION=5.6.0
+ENV KUSTOMIZE_VERSION=5.7.1
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -157,7 +157,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # HELM https://github.com/helm/helm/releases
 # ========================================
 
-ENV HELM_VERSION=3.17.3
+ENV HELM_VERSION=3.17.4
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -174,7 +174,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # Flux CD https://github.com/fluxcd/flux2/releases
 # ========================================
 
-ENV FLUXCD_VERSION=2.5.1
+ENV FLUXCD_VERSION=2.6.4
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -191,7 +191,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # Go https://go.dev/dl/
 # ========================================
 
-ENV GO_VERSION=1.24.3
+ENV GO_VERSION=1.24.6
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -206,7 +206,7 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 # Eksctl https://github.com/eksctl-io/eksctl/releases
 # ========================================
 
-ENV EKSCTL_VERSION=0.207.0
+ENV EKSCTL_VERSION=0.212.0
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -223,7 +223,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # k9s https://github.com/derailed/k9s/releases
 # ========================================
 
-ENV K9S_VERSION=0.50.6
+ENV K9S_VERSION=0.50.9
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -239,7 +239,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # ========================================
 # 1Password CLI https://app-updates.agilebits.com/product_history/CLI2
 # ========================================
-ENV OP_CLI_VERSION=v2.31.0
+ENV OP_CLI_VERSION=v2.31.1
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \
@@ -251,7 +251,7 @@ RUN export BUILD_ARCHITECTURE=$(uname -m); \
 # ========================================
 # Mimirtool https://github.com/grafana/mimir/releases/
 # ========================================
-ENV MIMIRTOOL_VERSION=2.15.2
+ENV MIMIRTOOL_VERSION=2.16.1
 
 RUN export BUILD_ARCHITECTURE=$(uname -m); \
     if [ "$BUILD_ARCHITECTURE" = "x86_64" ]; then export BUILD_ARCHITECTURE_ARCH=amd64; fi; \


### PR DESCRIPTION
## Describe your changes

This pull request updates several tool versions in the `Dockerfile` to ensure the build uses the latest releases and security patches. The changes are grouped by tool category for easier reference.

Cloud & Infrastructure Tools:

* Updated `AWS_CLI_VERSION` to 2.28.8 for the AWS CLI.
* Updated `OPENTOFU_VERSION` to 1.10.5 for OpenTofu.
* Updated `TERRAGRUNT_VERSION` to 0.84.1 for Terragrunt.
* Updated `EKSCTL_VERSION` to 0.212.0 for eksctl.

Kubernetes & DevOps Tools:

* Updated `KUSTOMIZE_VERSION` to 5.7.1 for Kustomize.
* Updated `HELM_VERSION` to 3.17.4 for Helm.
* Updated `FLUXCD_VERSION` to 2.6.4 for Flux CD.
* Updated `K9S_VERSION` to 0.50.9 for k9s.

Programming Languages & CLI Tools:

* Updated `GO_VERSION` to 1.24.6 for Go.
* Updated `OP_CLI_VERSION` to v2.31.1 for 1Password CLI.
* Updated `MIMIRTOOL_VERSION` to 2.16.1 for Mimirtool.

## Checklist before requesting a review
- [x] I have rebased or merged in the latest from the default branch.
- [x] I have tested changes locally using ```docker build .```
