### PR TITLE
Update branch references and shared workflow version in automation build

### DIFF
--- a/.github/workflows/automation-multi-build.yml
+++ b/.github/workflows/automation-multi-build.yml
@@ -2,16 +2,16 @@ name: Multi architecture docker build
 
 on:
   push:
-    branches: [ "master", "main" ]
+    branches: [ "master" ]
     paths:
       - "Dockerfile"
       - "src/**"
-  
+
   workflow_dispatch:
 
 jobs:
   shared:
-    uses: dfds/shared-workflows/.github/workflows/automation-multi-build.yml@master
+    uses: dfds/shared-workflows/.github/workflows/automation-multi-build.yml@v2.0.1
     secrets: inherit
     with:
       image-repo: dfdsdk/prime-pipeline


### PR DESCRIPTION
This pull request updates the multi-architecture Docker build workflow. The most important changes are focused on improving workflow stability and ensuring compatibility with the latest shared workflow version.

**Workflow configuration updates:**

* The workflow will now only trigger on pushes to the `master` branch, instead of both `master` and `main`.

**Dependency updates:**

* The workflow now uses version `v2.0.1` of the shared workflow (`dfds/shared-workflows/.github/workflows/automation-multi-build.yml`) instead of tracking the `master` branch, ensuring more predictable and stable builds.