### PR TITLE
both scripts fails silently on error

### DIFF
--- a/src/permanent/scripts/wait-for-asgs.sh
+++ b/src/permanent/scripts/wait-for-asgs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e pipefail
+
 # Check if eksctl and aws are installed
 command -v aws >/dev/null 2>&1 || { echo >&2 "aws CLI is required but not installed. Aborting."; exit 1; }
 

--- a/src/permanent/scripts/wait-for-ngs.sh
+++ b/src/permanent/scripts/wait-for-ngs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e pipefail
+
 # Check if eksctl and aws are installed
 command -v aws >/dev/null 2>&1 || { echo >&2 "aws CLI is required but not installed. Aborting."; exit 1; }
 


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Both wait-for-ngs.sh and wait-for-asgs.sh fails silently on error, so we need to add `set -e pipefail` to ensure the script throws an error on failure.

See this run https://github.com/dfds/eks-pipeline/actions/runs/27547682312/job/81425624748

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have rebased or merged in the latest from the default branch.
- [x] I have tested changes locally using ```docker build .```
