### PR TITLE
Fix silent errors part two

### DIFF
--- a/src/permanent/scripts/wait-for-asgs.sh
+++ b/src/permanent/scripts/wait-for-asgs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e pipefail
+set -eo pipefail
 
 # Check if eksctl and aws are installed
 command -v aws >/dev/null 2>&1 || { echo >&2 "aws CLI is required but not installed. Aborting."; exit 1; }

--- a/src/permanent/scripts/wait-for-ngs.sh
+++ b/src/permanent/scripts/wait-for-ngs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e pipefail
+set -eo pipefail
 
 # Check if eksctl and aws are installed
 command -v aws >/dev/null 2>&1 || { echo >&2 "aws CLI is required but not installed. Aborting."; exit 1; }


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
Prime-pipeline docker v2.2.5 has en issue with wait-for-{ngs,asgs}.sh script because I set `set -e pipefail`  and it should really be `set -eo pipefail`

## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [x] I have rebased or merged in the latest from the default branch.
- [ ] I have tested changes locally using ```docker build .```
